### PR TITLE
解决不提取枯竭钍等燃料棒的问题

### DIFF
--- a/nuclearReactor.lua
+++ b/nuclearReactor.lua
@@ -84,7 +84,8 @@ local function check()
             checkHasFuelRods()
             transposer.transferItem(me_interface, reactor, 1, me_interfaceFuelRodsIndex, i)
         else
-            if item['maxDamage'] == 0 then
+            local name = item['name']
+            if item['maxDamage'] == 0 or (string.find(name, "Dep") == string.len(name) - 2) then
                 checkHasFuelRods()
                 transposer.transferItem(reactor, me_interface, 1, i, me_interfaceEmptyIndex)
                 transposer.transferItem(me_interface, reactor, 1, me_interfaceFuelRodsIndex, i)


### PR DESCRIPTION
钍、泰伯利亚、硅岩、超能硅岩、核心五种燃料棒的枯竭形态有100/100的耐久度属性，用maxDamage判断会识别不到，所以加一条用name判断的，上述五种枯竭棒的name都是以“Dep”结尾