### PR TITLE
防止热更换燃料棒造成冷却单元损坏核电升温

### DIFF
--- a/nuclearReactor.lua
+++ b/nuclearReactor.lua
@@ -78,13 +78,25 @@ local function check()
         shutdown()
     end
 
+    flag = 0
+    
     for _, i in pairs(reactorFuelRodsIndex) do --check whether has dried fuel or empty slot
         local item = reactorItems[i - 1]
         if next(item) == nil then
+            pause()
+            if flag == 0 then
+                flag = 1
+                sleep(1)
+            end
             checkHasFuelRods()
             transposer.transferItem(me_interface, reactor, 1, me_interfaceFuelRodsIndex, i)
         else
             if item['maxDamage'] == 0 then
+                pause()
+                if flag == 0 then
+                    flag = 1
+                    sleep(1)
+                end
                 checkHasFuelRods()
                 transposer.transferItem(reactor, me_interface, 1, i, me_interfaceEmptyIndex)
                 transposer.transferItem(me_interface, reactor, 1, me_interfaceFuelRodsIndex, i)


### PR DESCRIPTION
防止检测燃料棒使用完毕后，更换燃料棒时仍处于开机状态，如果替换速度慢会导致低热容（60k冷却单元）冷却单元损坏的问题发生造成核电升温。